### PR TITLE
Rhythmiq #940

### DIFF
--- a/include/dkm.hpp
+++ b/include/dkm.hpp
@@ -9,10 +9,14 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <random>
 #include <tuple>
 #include <type_traits>
 #include <vector>
+
+#if defined(_DEBUG) && (defined(WIN32) || defined(_WINDOWS))
+#undef _DEBUG
+#endif
+#include <random>
 
 /*
 DKM - A k-means implementation that is generic across variable data dimensions.
@@ -121,7 +125,18 @@ std::vector<std::array<T, N>> random_plusplus(const std::vector<std::array<T, N>
 		input_size_t i = 0;
 		std::discrete_distribution<input_size_t> generator(distances.size(), 0.0, 0.0, [&distances, &i](double) { return distances[i++]; });
 #endif
-		means.push_back(data[generator(rand_engine)]);
+        if (std::isnan(generator.probabilities()[0]))
+        {
+            means.push_back(data[0]);
+        }
+        //if (std::isnan(generator._Par._Pvec[0]))
+        //{
+        //    means.push_back(data[0]);
+        //}
+        else
+        {
+            means.push_back(data[generator(rand_engine)]);
+        }
 	}
 	return means;
 }

--- a/include/dkm.hpp
+++ b/include/dkm.hpp
@@ -125,18 +125,12 @@ std::vector<std::array<T, N>> random_plusplus(const std::vector<std::array<T, N>
 		input_size_t i = 0;
 		std::discrete_distribution<input_size_t> generator(distances.size(), 0.0, 0.0, [&distances, &i](double) { return distances[i++]; });
 #endif
-        if (std::isnan(generator.probabilities()[0]))
+        auto index = generator(rand_engine);
+        if (index == generator.probabilities().size())
         {
-            means.push_back(data[0]);
+            index = 0;
         }
-        //if (std::isnan(generator._Par._Pvec[0]))
-        //{
-        //    means.push_back(data[0]);
-        //}
-        else
-        {
-            means.push_back(data[generator(rand_engine)]);
-        }
+        means.push_back(data[index]);
 	}
 	return means;
 }

--- a/include/dkm.hpp
+++ b/include/dkm.hpp
@@ -15,8 +15,11 @@
 
 #if defined(_DEBUG) && (defined(WIN32) || defined(_WINDOWS))
 #undef _DEBUG
-#endif
 #include <random>
+#define _DEBUG
+#else
+#include <random>
+#endif
 
 /*
 DKM - A k-means implementation that is generic across variable data dimensions.


### PR DESCRIPTION
Fix for issues related to rhythmiq-#940
(Just copied commit message here)

1) #undef _DEBUG if _DEBUG and (WIN32 or _WINDOWS) have been defined before including <random>
- This in effect prevents definition of _RNG_ASSERT
- Keep an eye for possible definitions of _RNG_CHECK in the future

2) If all distances are 0, generator.probabilities() does return a vector of proper size, but all NaNs
- In this case, generator will return its size as the next value (so out of range for indexind data)
	- Just use data[0]