### PR TITLE
Dkm add parallel bestkmeans

### DIFF
--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -123,14 +123,13 @@ template <typename T, size_t N>
 std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> kmeans_lloyd_parallel(
 	const std::vector<std::array<T, N>>& data,
 	const clustering_parameters<T>& parameters, 
-	CustomGenerator& rand_engine=CustomGenerator(0)) 
+	const CustomGenerator& rand_engine = CustomGenerator(0)) 
 {
 	static_assert(std::is_arithmetic<T>::value && std::is_signed<T>::value,
 		"kmeans_lloyd requires the template parameter T to be a signed arithmetic type (e.g. float, double, int)");
 	assert(parameters.get_k() > 0); // k must be greater than zero
 	assert(data.size() >= parameters.get_k()); // there must be at least k data points
-
-	std::vector<std::array<T, N>> means = details::random_plusplus_parallel(data, parameters.get_k(), rand_engine);
+	std::vector<std::array<T, N>> means = details::random_plusplus_parallel(data, parameters.get_k(), const_cast<CustomGenerator&>(rand_engine));
 
 	std::vector<std::array<T, N>> old_means;
 	std::vector<std::array<T, N>> old_old_means;

--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -17,6 +17,8 @@
 #include "dkm.hpp"
 #include "dkm_utils.hpp""
 
+// Using a very simple PRBS generator, parameters selected according to
+// https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use
 using CustomGenerator = std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX>;
 
 /*
@@ -61,9 +63,6 @@ std::vector<std::array<T, N>> random_plusplus_parallel(
 	assert(data.size() > 0);
 	using input_size_t = typename std::array<T, N>::size_type;
 	std::vector<std::array<T, N>> means;
-	// Using a very simple PRBS generator, parameters selected according to
-	// https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use
-	//std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX> rand_engine(seed);
 
 	// Select first mean at random from the set
 	{
@@ -119,7 +118,7 @@ Returns a std::tuple containing:
 Implementation details:
 This implementation of k-means uses [Lloyd's Algorithm](https://en.wikipedia.org/wiki/Lloyd%27s_algorithm)
 with the [kmeans++](https://en.wikipedia.org/wiki/K-means%2B%2B)
-used for initializing the means.
+used for initializing the means. An optional argument for a seeded generator is also provided.
 */
 template <typename T, size_t N>
 std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> kmeans_lloyd_parallel(
@@ -131,9 +130,6 @@ std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> kmeans_lloyd_pa
 		"kmeans_lloyd requires the template parameter T to be a signed arithmetic type (e.g. float, double, int)");
 	assert(parameters.get_k() > 0); // k must be greater than zero
 	assert(data.size() >= parameters.get_k()); // there must be at least k data points
-	//std::random_device rand_device;
-	//uint64_t seed = parameters.has_random_seed() ? parameters.get_random_seed() : rand_device();
-	//std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX> rand_engine(seed);
 
 	std::vector<std::array<T, N>> means = details::random_plusplus_parallel(data, parameters.get_k(), rand_engine);
 

--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 
 #include "dkm.hpp"
-#include "dkm_utils.hpp""
+#include "dkm_utils.hpp"
 
 // Using a very simple PRBS generator, parameters selected according to
 // https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use

--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -17,6 +17,8 @@
 #include "dkm.hpp"
 #include "dkm_utils.hpp""
 
+using CustomGenerator = std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX>;
+
 /*
 DKM - A k-means implementation that is generic across variable data dimensions.
 */
@@ -53,14 +55,15 @@ This is an alternate initialization method based on the [kmeans++](https://en.wi
 initialization algorithm.
 */
 template <typename T, size_t N>
-std::vector<std::array<T, N>> random_plusplus_parallel(const std::vector<std::array<T, N>>& data, uint32_t k, uint64_t seed) {
+std::vector<std::array<T, N>> random_plusplus_parallel(
+	const std::vector<std::array<T, N>>& data, uint32_t k, CustomGenerator& rand_engine) {
 	assert(k > 0);
 	assert(data.size() > 0);
 	using input_size_t = typename std::array<T, N>::size_type;
 	std::vector<std::array<T, N>> means;
 	// Using a very simple PRBS generator, parameters selected according to
 	// https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use
-	std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX> rand_engine(seed);
+	//std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX> rand_engine(seed);
 
 	// Select first mean at random from the set
 	{
@@ -120,14 +123,19 @@ used for initializing the means.
 */
 template <typename T, size_t N>
 std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> kmeans_lloyd_parallel(
-	const std::vector<std::array<T, N>>& data, const clustering_parameters<T>& parameters) {
+	const std::vector<std::array<T, N>>& data,
+	const clustering_parameters<T>& parameters, 
+	CustomGenerator& rand_engine=CustomGenerator(0)) 
+{
 	static_assert(std::is_arithmetic<T>::value && std::is_signed<T>::value,
 		"kmeans_lloyd requires the template parameter T to be a signed arithmetic type (e.g. float, double, int)");
 	assert(parameters.get_k() > 0); // k must be greater than zero
 	assert(data.size() >= parameters.get_k()); // there must be at least k data points
-	std::random_device rand_device;
-	uint64_t seed = parameters.has_random_seed() ? parameters.get_random_seed() : rand_device();
-	std::vector<std::array<T, N>> means = details::random_plusplus_parallel(data, parameters.get_k(), seed);
+	//std::random_device rand_device;
+	//uint64_t seed = parameters.has_random_seed() ? parameters.get_random_seed() : rand_device();
+	//std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX> rand_engine(seed);
+
+	std::vector<std::array<T, N>> means = details::random_plusplus_parallel(data, parameters.get_k(), rand_engine);
 
 	std::vector<std::array<T, N>> old_means;
 	std::vector<std::array<T, N>> old_old_means;
@@ -155,7 +163,9 @@ Any code still using this signature should move to the version of this function 
 template <typename T, size_t N>
 std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> kmeans_lloyd_parallel(
 	const std::vector<std::array<T, N>>& data, uint32_t k,
-	uint64_t max_iter = 0, T min_delta = -1.0) {
+	uint64_t max_iter = 0,
+	T min_delta = -1.0
+	) {
 	clustering_parameters<T> parameters(k);
 	if (max_iter != 0) {
 		parameters.set_max_iteration(max_iter);

--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "dkm.hpp"
+#include "dkm_utils.hpp""
 
 /*
 DKM - A k-means implementation that is generic across variable data dimensions.

--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "dkm.hpp"
-#include "dkm_utils.hpp"
 
 // Using a very simple PRBS generator, parameters selected according to
 // https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use

--- a/include/dkm_utils.hpp
+++ b/include/dkm_utils.hpp
@@ -143,11 +143,18 @@ std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> get_best_means(
 	template <typename T, size_t N>
 	std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> get_best_means_parallel(
 	const std::vector<std::array<T, N>>& points, const clustering_parameters<T>& parameters, uint32_t n_init = 10) {
-		auto best_means = kmeans_lloyd_parallel(points, parameters);
+
+		// seed generator once 
+		std::random_device rand_device;
+		uint64_t seed = parameters.has_random_seed() ? parameters.get_random_seed() : rand_device();
+		std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX> rand_engine(seed);
+
+
+		auto best_means = kmeans_lloyd_parallel(points, parameters, rand_engine);
 		auto best_inertia = means_inertia(points, best_means, parameters.get_k());
 
 		for (uint32_t i = 0; i < n_init - 1; ++i) {
-			auto curr_means = kmeans_lloyd_parallel(points, parameters);
+			auto curr_means = kmeans_lloyd_parallel(points, parameters, rand_engine);
 			auto curr_inertia = means_inertia(points, curr_means, parameters.get_k());
 			if (curr_inertia < best_inertia) {
 				best_inertia = curr_inertia;

--- a/include/dkm_utils.hpp
+++ b/include/dkm_utils.hpp
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <vector>
 
+#include "dkm_parallel.hpp"
 #include "dkm.hpp"
 
 namespace dkm {
@@ -123,5 +124,38 @@ std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> get_best_means(
 	// copy and return
 	return best_means;
 }
+
+
+
+
+    /**
+	 * Return the best clustering obtained from a given number of k-means
+	 * calculations.
+	 *
+	 * @param points  Sequence of points to be clustered.
+	 * @param k		  Number of clusters
+	 * @param n_init  Number of times a k-means clustering will be calculated.
+	 *
+	 * @return Clustering with the lowest inertia.
+	 */
+
+
+	template <typename T, size_t N>
+	std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> get_best_means_parallel(
+	const std::vector<std::array<T, N>>& points, const clustering_parameters<T>& parameters, uint32_t n_init = 10) {
+		auto best_means = kmeans_lloyd_parallel(points, parameters);
+		auto best_inertia = means_inertia(points, best_means, parameters.get_k());
+
+		for (uint32_t i = 0; i < n_init - 1; ++i) {
+			auto curr_means = kmeans_lloyd_parallel(points, parameters);
+			auto curr_inertia = means_inertia(points, curr_means, parameters.get_k());
+			if (curr_inertia < best_inertia) {
+				best_inertia = curr_inertia;
+				best_means = curr_means;
+			}
+		}
+		// copy and return
+		return best_means;
+	}
 
 } // namespace dkm

--- a/include/dkm_utils.hpp
+++ b/include/dkm_utils.hpp
@@ -132,9 +132,9 @@ std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> get_best_means(
 	 * Return the best clustering obtained from a given number of k-means
 	 * calculations.
 	 *
-	 * @param points  Sequence of points to be clustered.
-	 * @param k		  Number of clusters
-	 * @param n_init  Number of times a k-means clustering will be calculated.
+	 * @param points		 Sequence of points to be clustered.
+	 * @param parameters	 Clustering related parameters.
+	 * @param n_init		 Number of times a k-means clustering will be calculated.
 	 *
 	 * @return Clustering with the lowest inertia.
 	 */
@@ -147,7 +147,7 @@ std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> get_best_means(
 		// seed generator once 
 		std::random_device rand_device;
 		uint64_t seed = parameters.has_random_seed() ? parameters.get_random_seed() : rand_device();
-		std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX> rand_engine(seed);
+		CustomGenerator rand_engine(seed);
 
 
 		auto best_means = kmeans_lloyd_parallel(points, parameters, rand_engine);


### PR DESCRIPTION
In this PR the `get_best_means_parallel()` is introduced so as to use the `kmeans_lloyd_parallel()` algorithm. Note that the existing `get_best_means` method used the `kmeans_lloyd()` algorithm, which we do not prefer, as it is slower.
The idea is to run multiple times the kmeans_lloyd_parallel() algorithm and keep the best result (intertia related criterion is used). As we want to have reproducible results, but different per kmeans run so as the whole idea to make sense, we instantiated a seeded generator once and passed this as an argument to the `kmeans_lloyd_parallel()`.