### PR TITLE
Replace the `std::uniform_int_distribution` with a simpler deterministic and cross-platform solution.

### DIFF
--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -18,8 +18,9 @@
 
 // Using a very simple PRBS generator, parameters selected according to
 // https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use
-using CustomGenerator = std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX>;
-
+//using CustomGenerator = std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX>;
+//using CustomGenerator = std::minstd_rand0;
+using CustomGenerator = std::mt19937;
 /*
 DKM - A k-means implementation that is generic across variable data dimensions.
 */

--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -57,7 +57,7 @@ initialization algorithm.
 */
 template <typename T, size_t N>
 std::vector<std::array<T, N>> random_plusplus_parallel(
-	const std::vector<std::array<T, N>>& data, uint32_t k, CustomGenerator& rand_engine, const int currentIteration, const int maxIterations) {
+	const std::vector<std::array<T, N>>& data, uint32_t k, CustomGenerator& rand_engine, const uint32_t currentIteration, const uint32_t maxIterations) {
 	assert(k > 0);
 	assert(data.size() > 0);
 	using input_size_t = typename std::array<T, N>::size_type;
@@ -66,8 +66,8 @@ std::vector<std::array<T, N>> random_plusplus_parallel(
 	// Select first mean at random from the set
 	{
         const int numFrames = data.size();
-        const int uniformSpacing = numFrames / maxIterations;
-        const int currentSampledFrame = currentIteration * uniformSpacing;
+        const int uniformSpacing = numFrames / static_cast<int>(maxIterations);
+        const int currentSampledFrame = static_cast<int>(currentIteration) * uniformSpacing;
 		means.push_back(data[currentSampledFrame]);
 	}
 
@@ -125,8 +125,8 @@ template <typename T, size_t N>
 std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> kmeans_lloyd_parallel(
 	const std::vector<std::array<T, N>>& data,
 	const clustering_parameters<T>& parameters,
-    const int currentIteration,
-    const int maxIterations,
+    const uint32_t currentIteration,
+    const uint32_t maxIterations,
 	const CustomGenerator& rand_engine = CustomGenerator(0))
 {
 	static_assert(std::is_arithmetic<T>::value && std::is_signed<T>::value,

--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -57,17 +57,21 @@ initialization algorithm.
 */
 template <typename T, size_t N>
 std::vector<std::array<T, N>> random_plusplus_parallel(
-	const std::vector<std::array<T, N>>& data, uint32_t k, CustomGenerator& rand_engine, const uint32_t currentIteration, const uint32_t maxIterations) {
+	const std::vector<std::array<T, N>>& data,
+    uint32_t k,
+    CustomGenerator& rand_engine,
+    const uint32_t currentClusteringRunId,
+    const uint32_t totalClusteringRuns) {
 	assert(k > 0);
 	assert(data.size() > 0);
 	using input_size_t = typename std::array<T, N>::size_type;
 	std::vector<std::array<T, N>> means;
 
-	// Select first mean at random from the set
+    // replaced the `std::uniform_int_distribution` with a simpler deterministic and cross-platform solution.
 	{
         const int numFrames = data.size();
-        const int uniformSpacing = numFrames / static_cast<int>(maxIterations);
-        const int currentSampledFrame = static_cast<int>(currentIteration) * uniformSpacing;
+        const int uniformSpacing = numFrames / static_cast<int>(totalClusteringRuns);
+        const int currentSampledFrame = static_cast<int>(currentClusteringRunId) * uniformSpacing;
 		means.push_back(data[currentSampledFrame]);
 	}
 
@@ -125,19 +129,25 @@ template <typename T, size_t N>
 std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> kmeans_lloyd_parallel(
 	const std::vector<std::array<T, N>>& data,
 	const clustering_parameters<T>& parameters,
-    const uint32_t currentIteration,
-    const uint32_t maxIterations,
+    const uint32_t currentClusteringRunId,
+    const uint32_t totalClusteringRuns,
 	const CustomGenerator& rand_engine = CustomGenerator(0))
 {
 	static_assert(std::is_arithmetic<T>::value && std::is_signed<T>::value,
 		"kmeans_lloyd requires the template parameter T to be a signed arithmetic type (e.g. float, double, int)");
 	assert(parameters.get_k() > 0); // k must be greater than zero
 	assert(data.size() >= parameters.get_k()); // there must be at least k data points
-	std::vector<std::array<T, N>> means = details::random_plusplus_parallel(data, parameters.get_k(), const_cast<CustomGenerator&>(rand_engine), currentIteration, maxIterations);
+    
+	std::vector<std::array<T, N>> means = details::random_plusplus_parallel(data,
+                                                                            parameters.get_k(),
+                                                                            const_cast<CustomGenerator&>(rand_engine),
+                                                                            currentClusteringRunId,
+                                                                            totalClusteringRuns);
 
 	std::vector<std::array<T, N>> old_means;
 	std::vector<std::array<T, N>> old_old_means;
 	std::vector<uint32_t> clusters;
+    
 	// Calculate new means until convergence is reached or we hit the maximum iteration count
 	uint64_t count = 0;
 	do {

--- a/include/dkm_parallel.hpp
+++ b/include/dkm_parallel.hpp
@@ -18,9 +18,8 @@
 
 // Using a very simple PRBS generator, parameters selected according to
 // https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use
-//using CustomGenerator = std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX>;
-//using CustomGenerator = std::minstd_rand0;
-using CustomGenerator = std::mt19937;
+using CustomGenerator = std::linear_congruential_engine<uint64_t, 6364136223846793005, 1442695040888963407, UINT64_MAX>;
+
 /*
 DKM - A k-means implementation that is generic across variable data dimensions.
 */

--- a/include/dkm_utils.hpp
+++ b/include/dkm_utils.hpp
@@ -150,11 +150,11 @@ std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> get_best_means(
 		CustomGenerator rand_engine(seed);
 
 
-		auto best_means = kmeans_lloyd_parallel(points, parameters, rand_engine);
+		auto best_means = kmeans_lloyd_parallel(points, parameters, 0, static_cast<int>(n_init), rand_engine);
 		auto best_inertia = means_inertia(points, best_means, parameters.get_k());
 
 		for (uint32_t i = 0; i < n_init - 1; ++i) {
-			auto curr_means = kmeans_lloyd_parallel(points, parameters, rand_engine);
+			auto curr_means = kmeans_lloyd_parallel(points, parameters, static_cast<int>(i+1), static_cast<int>(n_init), rand_engine);
 			auto curr_inertia = means_inertia(points, curr_means, parameters.get_k());
 			if (curr_inertia < best_inertia) {
 				best_inertia = curr_inertia;

--- a/include/dkm_utils.hpp
+++ b/include/dkm_utils.hpp
@@ -150,11 +150,11 @@ std::tuple<std::vector<std::array<T, N>>, std::vector<uint32_t>> get_best_means(
 		CustomGenerator rand_engine(seed);
 
 
-		auto best_means = kmeans_lloyd_parallel(points, parameters, 0, static_cast<int>(n_init), rand_engine);
+		auto best_means = kmeans_lloyd_parallel(points, parameters, 0, n_init, rand_engine);
 		auto best_inertia = means_inertia(points, best_means, parameters.get_k());
 
 		for (uint32_t i = 0; i < n_init - 1; ++i) {
-			auto curr_means = kmeans_lloyd_parallel(points, parameters, static_cast<int>(i+1), static_cast<int>(n_init), rand_engine);
+			auto curr_means = kmeans_lloyd_parallel(points, parameters, i + 1, n_init, rand_engine);
 			auto curr_inertia = means_inertia(points, curr_means, parameters.get_k());
 			if (curr_inertia < best_inertia) {
 				best_inertia = curr_inertia;


### PR DESCRIPTION
### Whats does this PR do
Replaces the `std::uniform_int_distribution` with a simpler deterministic and cross-platform solution. In detail, the initial means of the 1st cluster are sampled from the input data from equally spaced indices across the length of the data matrix (num. samples dimension).

### Notes to the reviewer
Please merge and delete the branch.